### PR TITLE
Make the main field rules.json to allow `extends` in tslint.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   "bugs": {
     "url": "https://github.com/Microsoft/tslint-microsoft-contrib/issues"
   },
-  "main": "package.json",
+  "main": "tslint.json",
   "keywords": [
     "tslint",
     "microsoft",


### PR DESCRIPTION
By changing the `main` field to `
